### PR TITLE
Fixes segfault when no releases exist.

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,16 +61,12 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(releases) == 0 {
-		if outputFormat == "plain" {
-			fmt.Println("No releases found. All up to date!")
-		}
+		fmt.Println("No releases found. All up to date!")
 		return nil
 	}
 
 	if len(repositories) == 0 {
-		if outputFormat == "plain" {
-			fmt.Println("No repositories found. Did you run `helm repo update`?")
-		}
+		fmt.Println("No repositories found. Did you run `helm repo update`?")
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -61,12 +61,16 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(releases) == 0 {
-		fmt.Println("No releases found. All up to date!")
+		if outputFormat == "plain" {
+			fmt.Println("No releases found. All up to date!")
+		}
 		return nil
 	}
 
 	if len(repositories) == 0 {
-		fmt.Println("No repositories found. Did you run `helm repo update`?")
+		if outputFormat == "plain" {
+			fmt.Println("No repositories found. Did you run `helm repo update`?")
+		}
 		return nil
 	}
 
@@ -125,6 +129,9 @@ func fetchReleases(client *helm.Client) ([]*release.Release, error) {
 	res, err := client.ListReleases()
 	if err != nil {
 		return nil, err
+	}
+	if res == nil {
+		return []*release.Release{}, nil
 	}
 	return res.Releases, nil
 }


### PR DESCRIPTION
When no releases exist (helm list empty) whatup raises panic: runtime error: invalid memory address or nil pointer dereference due to the fact that the result of client.ListReleases is empty.