### PR TITLE
Fixes non-plain output

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	if len(releases) == 0 {
 		if outputFormat == 'plain' {
-     	    fmt.Println("No releases found. All up to date!")
+ 			fmt.Println("No releases found. All up to date!")
 		}
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	if len(releases) == 0 {
 		if outputFormat == 'plain' {
-     		fmt.Println("No releases found. All up to date!")
+     	    fmt.Println("No releases found. All up to date!")
 		}
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -61,12 +61,16 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(releases) == 0 {
-		fmt.Println("No releases found. All up to date!")
+		if outputFormat == 'plain' {
+     		fmt.Println("No releases found. All up to date!")
+		}
 		return nil
 	}
 
 	if len(repositories) == 0 {
-		fmt.Println("No repositories found. Did you run `helm repo update`?")
+		if outputFormat == 'plain' {
+			fmt.Println("No repositories found. Did you run `helm repo update`?")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Only returns messages when output format is plain, otherwise
whatup would return non valid json.