### PR TITLE
Adds pre-release support

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ Check to see if there is an updated version available for installed charts.
 `
 
 var outputFormat string
+var devel bool
 
 var version = "canary"
 
@@ -42,6 +43,7 @@ func main() {
 	}
 
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "plain", "Output format, choose from plain, json, yaml")
+	cmd.Flags().BoolVarP(&devel, "devel", "d", false, "Wether to include pre-releases or not, defaults to false.")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
@@ -52,6 +54,7 @@ func run(cmd *cobra.Command, args []string) error {
 	client := helm.NewClient(helm.Host(os.Getenv("TILLER_HOST")))
 
 	releases, err := fetchReleases(client)
+	fmt.Printf("Test: %+v", len(releases))
 	if err != nil {
 		return err
 	}
@@ -81,7 +84,12 @@ func run(cmd *cobra.Command, args []string) error {
 		for _, idx := range repositories {
 			if idx.Has(release.Chart.Metadata.Name, release.Chart.Metadata.Version) {
 				// fetch latest release
-				chartVer, err := idx.Get(release.Chart.Metadata.Name, "")
+				constraint := ""
+				// Include pre-releases
+				if devel {
+					constraint = ">= *-0"
+				}
+				chartVer, err := idx.Get(release.Chart.Metadata.Name, constraint)
 				if err != nil {
 					return err
 				}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
+	"github.com/Masterminds/semver"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/release"
 	"k8s.io/helm/pkg/repo"
@@ -54,7 +55,6 @@ func run(cmd *cobra.Command, args []string) error {
 	client := helm.NewClient(helm.Host(os.Getenv("TILLER_HOST")))
 
 	releases, err := fetchReleases(client)
-	fmt.Printf("Test: %+v", len(releases))
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "plain", "Output format, choose from plain, json, yaml")
-	cmd.Flags().BoolVarP(&devel, "devel", "d", false, "Wether to include pre-releases or not, defaults to false.")
+	cmd.Flags().BoolVarP(&devel, "devel", "d", false, "Whether to include pre-releases or not, defaults to false.")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/Masterminds/semver"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/release"
 	"k8s.io/helm/pkg/repo"


### PR DESCRIPTION
Adds a --devel (-d) flag to support listing and evaluation of
pre-releases similar to helm list.