### PR TITLE
add `short` format

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	f := cmd.Flags()
 
-	f.StringVarP(&outputFormat, "output", "o", "plain", "output format. Accepted formats: plain, json, yaml, table")
+	f.StringVarP(&outputFormat, "output", "o", "plain", "output format. Accepted formats: plain, json, yaml, table, short")
 	f.BoolVarP(&devel, "devel", "d", false, "whether to include pre-releases or not")
 	f.BoolVar(&tlsEnable, "tls", false, "enable TLS for requests to the server")
 	f.StringVar(&tlsCaCert, "tls-ca-cert", "", "path to TLS CA certificate file")
@@ -216,6 +216,12 @@ func run(cmd *cobra.Command, args []string) error {
 			}
 		}
 		fmt.Println("Done.")
+	case "short":
+		for _, versionInfo := range result {
+			if versionInfo.LatestVersion != versionInfo.InstalledVersion {
+				fmt.Printf("%s (%s): %s --> %s\n", versionInfo.ReleaseName, versionInfo.ChartName, versionInfo.InstalledVersion, versionInfo.LatestVersion)
+			}
+		}
 	case "json":
 		outputBytes, err := json.MarshalIndent(result, "", "    ")
 		if err != nil {


### PR DESCRIPTION
Adds a new output format, so it's a little bit easier to check what needs an update in a single glance with this flag. I was bored of doing ` helm whatup -o table | grep -v UPTODATE`, have been using this patch in my local for a while, and just thought why not create a PR.

Any suggestions are welcome.

New `short` format output:
```
home-assistant (home-assistant): 0.9.11 --> 0.10.0
kubecost (cost-analyzer): 1.49.3 --> 1.50.0
prometheus-operator (prometheus-operator): 8.3.3 --> 8.5.0
prometheus (prometheus): 9.7.0 --> 9.7.2
steely-walrus (memcached): 3.0.17 --> 4.1.0
```

A default `plain` output is quite cryptic to see what needs an update:
```
Release auth (2.1.1) is up to date.
Release cert-manager (v0.12.0) is up to date.
Release grafana (4.2.2) is up to date.
Release helm-exporter (0.2.2) is up to date.
There is an update available for release home-assistant (home-assistant)!
Installed version: 0.9.11
Available version: 0.10.0
Release ingress (1.27.0) is up to date.
There is an update available for release kubecost (cost-analyzer)!
Installed version: 1.49.3
Available version: 1.50.0
Release plex (0.2.4) is up to date.
There is an update available for release prometheus-operator (prometheus-operator)!
Installed version: 8.3.3
Available version: 8.5.0
There is an update available for release prometheus (prometheus)!
Installed version: 9.7.0
Available version: 9.7.2
There is an update available for release steely-walrus (memcached)!
Installed version: 3.0.17
Available version: 4.1.0
Release ui (1.10.1) is up to date.
Done.
```